### PR TITLE
Update tentris script template

### DIFF
--- a/roles/iguana_suites/templates/httpQM.suite
+++ b/roles/iguana_suites/templates/httpQM.suite
@@ -6,6 +6,20 @@ connections:
     endpoint: "{{ item[0].connection_url | replace('%d', item[1].name) }}"
 
 tasks:
+  # this stresstest is used to warmup the benchmarked system
+  - className: "Stresstest"
+    configuration:
+      noOfQueryMixes: 1
+      queryHandler:
+        className: "InstancesQueryHandler"
+      workers:
+        - threads: {{ item[2].number }}
+          className: "HttpGetWorker"
+          language: "lang.SIMPLE"
+          responseType: "application/sparql-results+json"
+          queriesFile: "{{ item[1].queries_path }}"
+          timeOut: {{ iguana_query_timeout }}
+  
   - className: "Stresstest"
     configuration:
       noOfQueryMixes: {{ iguana_query_mixes_limit }}
@@ -19,8 +33,7 @@ tasks:
           queriesFile: "{{ item[1].queries_path }}"
           timeOut: {{ iguana_query_timeout }}
 
-preScriptHook: "{{ target_dir }}/iguana_suites/http/{{ item[0].name }}/{{ item[1].name }}/{{ item[2].number }}-start.sh"
-postScriptHook: "{{ target_dir }}/iguana_suites/http/{{ item[0].name }}/stop.sh"
+# for the warmup to take effect, we need to run the start and stop scripts outside of iguana
 
 #optional otherwise the same metrics will be used as default
 metrics:

--- a/roles/iguana_suites/templates/httpT.suite
+++ b/roles/iguana_suites/templates/httpT.suite
@@ -6,6 +6,20 @@ connections:
     endpoint: "{{ item[0].connection_url | replace('%d', item[1].name) }}"
 
 tasks:
+  # this stresstest is used to warmup the benchmarked system
+  - className: "Stresstest"
+    configuration:
+      noOfQueryMixes: 1
+      queryHandler:
+        className: "InstancesQueryHandler"
+      workers:
+        - threads: {{ item[2].number }}
+          className: "HttpGetWorker"
+          language: "lang.SIMPLE"
+          responseType: "application/sparql-results+json"
+          queriesFile: "{{ item[1].queries_path }}"
+          timeOut: {{ iguana_query_timeout }}
+
   - className: "Stresstest"
     configuration:
       # 1 hour (time Limit is in ms)
@@ -20,8 +34,7 @@ tasks:
           queriesFile: "{{ item[1].queries_path }}"
           timeOut: {{ iguana_query_timeout }}
 
-preScriptHook: "{{ target_dir }}/iguana_suites/http/{{ item[0].name }}/{{ item[1].name }}/{{ item[2].number }}-start.sh"
-postScriptHook: "{{ target_dir }}/iguana_suites/http/{{ item[0].name }}/stop.sh"
+# for the warmup to take effect, we need to run the start and stop scripts outside of iguana
 
 #optional otherwise the same metrics will be used as default
 metrics:

--- a/roles/iguana_suites/templates/tentris-httpQM.suite
+++ b/roles/iguana_suites/templates/tentris-httpQM.suite
@@ -6,9 +6,22 @@ connections:
     endpoint: "http://localhost:9080/stream"
 
 tasks:
+  # this stresstest is used to warmup the benchmarked system
   - className: "Stresstest"
     configuration:
-      # 1 hour (time Limit is in ms)
+      noOfQueryMixes: 1
+      queryHandler:
+        className: "InstancesQueryHandler"
+      workers:
+        - threads: {{ item[2].number }}
+          className: "HttpGetWorker"
+          language: "lang.SIMPLE"
+          responseType: "application/sparql-results+json"
+          queriesFile: "{{ item[1].queries_path }}"
+          timeOut: {{ iguana_query_timeout }}
+
+  - className: "Stresstest"
+    configuration:
       noOfQueryMixes: {{ iguana_query_mixes_limit }}
       queryHandler:
         className: "InstancesQueryHandler"
@@ -20,8 +33,7 @@ tasks:
           queriesFile: "{{ item[1].queries_path }}"
           timeOut: {{ iguana_query_timeout }}
 
-preScriptHook: "{{ target_dir }}/iguana_suites/http/tentris-{{ item[0] }}/{{ item[1].name }}/{{ item[2].number }}-start.sh"
-postScriptHook: "{{ target_dir }}/iguana_suites/http/tentris-{{ item[0] }}/stop.sh"
+# for the warmup to take effect, we need to run the start and stop scripts outside of iguana
 
 #optional otherwise the same metrics will be used as default
 metrics:

--- a/roles/iguana_suites/templates/tentris-httpT.suite
+++ b/roles/iguana_suites/templates/tentris-httpT.suite
@@ -6,6 +6,20 @@ connections:
     endpoint: "http://localhost:9080/stream"
 
 tasks:
+  # this stresstest is used to warmup the benchmarked system
+  - className: "Stresstest"
+    configuration:
+      noOfQueryMixes: 1
+      queryHandler:
+        className: "InstancesQueryHandler"
+      workers:
+        - threads: {{ item[2].number }}
+          className: "HttpGetWorker"
+          language: "lang.SIMPLE"
+          responseType: "application/sparql-results+json"
+          queriesFile: "{{ item[1].queries_path }}"
+          timeOut: {{ iguana_query_timeout }}
+
   - className: "Stresstest"
     configuration:
       # 1 hour (time Limit is in ms)
@@ -20,8 +34,7 @@ tasks:
           queriesFile: "{{ item[1].queries_path }}"
           timeOut: {{ iguana_query_timeout }}
 
-preScriptHook: "{{ target_dir }}/iguana_suites/http/tentris-{{ item[0] }}/{{ item[1].name }}/{{ item[2].number }}-start.sh"
-postScriptHook: "{{ target_dir }}/iguana_suites/http/tentris-{{ item[0] }}/stop.sh"
+# for the warmup to take effect, we need to run the start and stop scripts outside of iguana
 
 #optional otherwise the same metrics will be used as default
 metrics:

--- a/roles/iguana_suites/templates/tentris-start.sh
+++ b/roles/iguana_suites/templates/tentris-start.sh
@@ -9,14 +9,7 @@ fi
 
 echo $(date --iso-8601) - Starting Tentris
 
-{{ target_dir }}/triplestores/tentris/{{ item[0] }}/tentris_server \
-    --loglevel debug \
-    --storage {{ target_dir }}/databases/tentris/{{ item[0] }}/{{ item[1].name }} \
-    --logfile false \
-    --timeout 3600 \
-    --logstdout \
-    </dev/null 2>&1 >{{ target_dir }}/logs/run/tentris-{{ item[0] }}-{{ item[1].name }}.log & disown
-
+{{ target_dir }}/triplestores/tentris/{{ item[0] }}/tentris -s {{ target_dir }}/databases/tentris/{{ item[0] }}/{{ item[1].name }} serve --request-timeout-ms 180000 > {{ target_dir }}/logs/run/tentris-{{ item[0] }}-{{ item[1].name }}-{{ item[2].number }}.log 2>&1 & disown
 pid=$!
 
 echo $pid > {{ target_dir }}/tentris.pid
@@ -30,7 +23,7 @@ do
     then
         break
     fi
-    sleep 2
+    sleep 1
 done
 
 echo $(date --iso-8601) - Tentris started and accepting connections

--- a/roles/iguana_suites/templates/tentris-start.sh
+++ b/roles/iguana_suites/templates/tentris-start.sh
@@ -9,7 +9,14 @@ fi
 
 echo $(date --iso-8601) - Starting Tentris
 
-{{ target_dir }}/triplestores/tentris/{{ item[0] }}/tentris_server -l 1000 -f {{ item[1].path }} --logfile false --logstdout </dev/null 2>&1 >{{ target_dir }}/logs/run/tentris-{{ item[0] }}-{{ item[1].name }}-{{ item[2].number }}.log & disown
+{{ target_dir }}/triplestores/tentris/{{ item[0] }}/tentris_server \
+    --loglevel debug \
+    --storage {{ target_dir }}/databases/tentris/{{ item[0] }}/{{ item[1].name }} \
+    --logfile false \
+    --timeout 3600 \
+    --logstdout \
+    </dev/null 2>&1 >{{ target_dir }}/logs/run/tentris-{{ item[0] }}-{{ item[1].name }}.log & disown
+
 pid=$!
 
 echo $pid > {{ target_dir }}/tentris.pid

--- a/roles/loaders/templates/tentris-load.sh
+++ b/roles/loaders/templates/tentris-load.sh
@@ -2,10 +2,4 @@
 
 mkdir -p {{ target_dir }}/databases/tentris/{{ item[0] }}
 
-{{ target_dir }}/triplestores/tentris/{{ item[0] }}/tentris_loader \
-    --logfile false \
-    --logstdout \
-    --file {{ item[1].path }} \
-    --storage {{ target_dir }}/databases/tentris/{{ item[0] }}/{{ item[1].name }} \
-    << EOF 2>&1 | tee {{ target_dir }}/logs/load/tentris-{{ item[0] }}-{{ item[1].name }}.log
-EOF
+cgmemtime {{ target_dir }}/triplestores/tentris/{{ item[0] }}/tentris -s {{ target_dir }}/databases/tentris/{{ item[0] }}/{{ item[1].name }} load < {{ item[1].path }} 2>&1 | tee {{ target_dir }}/logs/load/tentris-{{ item[0] }}-{{ item[1].name }}.log

--- a/roles/loaders/templates/tentris-load.sh
+++ b/roles/loaders/templates/tentris-load.sh
@@ -1,4 +1,11 @@
 #! /bin/bash
 
-cgmemtime  {{ target_dir }}/triplestores/tentris/{{ item[0] }}/tentris_terminal --logfile false --logstdout -f {{ item[1].path }} << EOF 2>&1 | tee {{ target_dir }}/logs/load/tentris-{{ item[0] }}-{{ item[1].name }}.log
+mkdir -p {{ target_dir }}/databases/tentris/{{ item[0] }}
+
+{{ target_dir }}/triplestores/tentris/{{ item[0] }}/tentris_loader \
+    --logfile false \
+    --logstdout \
+    --file {{ item[1].path }} \
+    --storage {{ target_dir }}/databases/tentris/{{ item[0] }}/{{ item[1].name }} \
+    << EOF 2>&1 | tee {{ target_dir }}/logs/load/tentris-{{ item[0] }}-{{ item[1].name }}.log
 EOF

--- a/roles/tentris/tasks/check_install.yaml
+++ b/roles/tentris/tasks/check_install.yaml
@@ -1,6 +1,6 @@
 - name: Check for tentris
   stat:
-    path: "{{ target_dir }}/triplestores/tentris/{{ tentris_version }}/tentris_server"
+    path: "{{ target_dir }}/triplestores/tentris/{{ tentris_version }}/tentris"
   register: tentris
 
 - include: install.yaml

--- a/roles/tentris/tasks/install.yaml
+++ b/roles/tentris/tasks/install.yaml
@@ -24,11 +24,11 @@
     path: "{{ target_dir }}/triplestores/tentris/{{ tentris_version }}"
     state: directory
 
-- name: Install tentris_server
+- name: Install tentris
   copy:
     remote_src: yes
-    src: "{{ tempdir.path }}/tentris_{{ tentris_version }}/tentris_server"
-    dest: "{{ target_dir }}/triplestores/tentris/{{ tentris_version }}/tentris_server"
+    src: "{{ tempdir.path }}/tentris_{{ tentris_version }}/tentris"
+    dest: "{{ target_dir }}/triplestores/tentris/{{ tentris_version }}/tentris"
     mode: 0755
 
 - name: Delete tempdir

--- a/roles/tentris_bench/files/run-bench.sh
+++ b/roles/tentris_bench/files/run-bench.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# add here the names of the triple stores you want to benchmark
+# the script should be run with sudo and in the home directory of the playbook on the server
+# Example: triplestores=( "fuseki" "virtuoso" "graphdb" "tentris" ) (Pay attention to the syntax of the list)
+triplestores=(  ) # add triplestores
+workers=1 # number of workers
+# set your dataset here (e.g., swdf)
+dataset=""
+echo "Running the benchmark"
+for ts in "${triplestores[@]}"
+do
+    # clear caches
+    echo 3 >/proc/sys/vm/drop_caches
+    # start the triple store
+    echo "$(date): Starting $ts" for "$dataset"
+    ./iguana_suites/http/"$ts"/"$dataset"/"$workers"-start.sh &> /dev/null
+    # start the suite
+    echo "$(date): Running IGUANA (Query Mixes) for $ts" and "$dataset"
+    ./iguana-run.sh ./iguana_suites/http/"$ts"/"$dataset"/"$workers"-QM.yml &> /dev/null
+    # stop the system
+    echo "$(date): Stopping $ts"
+    ./iguana_suites/http/"$ts"/stop.sh &> /dev/null
+done

--- a/roles/tentris_bench/tasks/main.yaml
+++ b/roles/tentris_bench/tasks/main.yaml
@@ -1,0 +1,5 @@
+- name: Copy benchmarking script
+  copy: 
+    src: run-bench.sh
+    dest: "{{ target_dir }}"
+    mode: 0755


### PR DESCRIPTION
The current script templates for tentris are outdated and don't work for the current versions for tentris. The commit should contain the correct templates.